### PR TITLE
Support allocated

### DIFF
--- a/fsel.go
+++ b/fsel.go
@@ -112,6 +112,12 @@ func runFunc(pass *analysis.Pass, fn *ssa.Function) {
 						if nilnessOf(stack, ptrerr.err) != isnil && nilnessOf(stack, ptrerr.ptr) != isnonnil {
 							pass.Reportf(instr.Pos(), "field address without checking nilness of err")
 						}
+					} else if alloc := refOfAllocated(instr.X); alloc != nil {
+						if latestAllocated[alloc] == ptrerr.ptr {
+							if nilnessOf(stack, ptrerr.err) != isnil && nilnessOf(stack, ptrerr.ptr) != isnonnil {
+								pass.Reportf(instr.Pos(), "field address without checking nilness of err")
+							}
+						}
 					}
 				}
 			case *ssa.Store:

--- a/fsel.go
+++ b/fsel.go
@@ -209,7 +209,7 @@ func runFunc(pass *analysis.Pass, fn *ssa.Function) {
 }
 
 // *t0 (t0 is a *ssa.Alloc) -> t0
-// otherwise return snil
+// otherwise returns nil
 func refOfAllocated(v ssa.Value) *ssa.Alloc {
 	if unop, ok := v.(*ssa.UnOp); ok {
 		if unop.Op == token.MUL {

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -32,6 +32,18 @@ func f4() error {
 	return nil
 }
 
+func f5() error {
+	s, err := newS()
+	if err != nil {
+		return err
+	}
+	println(s.X) // ok because err is nil
+	func() {
+		println(err)
+	}()
+	return nil
+}
+
 func g1() error {
 	var t T
 	s, err := t.S()

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -38,10 +38,48 @@ func f5() error {
 		return err
 	}
 	println(s.X) // ok because err is nil
-	func() {
-		println(err)
-	}()
+	func() { println(err) }()
 	return nil
+}
+
+func f6() error {
+	s, err := newS()
+	if err != nil {
+		return err
+	}
+	s, err = newS()
+	println(s.X) // want "field address"
+	func() { println(err) }()
+	return nil
+}
+
+func f7() error {
+	s, err := newS()
+	if err != nil {
+		return err
+	}
+	s, err = newS()
+	if err != nil {
+		return err
+	}
+	println(s.X) // ok
+	func() { println(err) }()
+	return nil
+}
+
+func f8() (err error) {
+	s, err := newS()
+	if err != nil {
+		return err
+	}
+	println(s.X) // ok because err is nil
+	return nil
+}
+
+func f9() (err error) {
+	s, err := newS()
+	println(s.X) // want "field address"
+	return err
 }
 
 func g1() error {
@@ -68,20 +106,4 @@ func g3() error {
 		println(s.X) // ok because s is not nil
 	}
 	return nil
-}
-
-func newS() (*S, error) {
-	return nil, nil
-}
-
-type S struct {
-	X int
-}
-
-type T struct {
-	X int
-}
-
-func (t T) S() (*S, error) {
-	return nil, nil
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -82,6 +82,13 @@ func f9() (err error) {
 	return err
 }
 
+func f10() error {
+	s, err := newS()
+	println(s.X) // want "field address"
+	func() { println(s.X) }()
+	return err
+}
+
 func g1() error {
 	var t T
 	s, err := t.S()

--- a/testdata/src/a/def.go
+++ b/testdata/src/a/def.go
@@ -1,0 +1,17 @@
+package a
+
+func newS() (*S, error) {
+	return nil, nil
+}
+
+type S struct {
+	X int
+}
+
+type T struct {
+	X int
+}
+
+func (t T) S() (*S, error) {
+	return nil, nil
+}


### PR DESCRIPTION
`err` is allocated.

```go
func f5() error {
	s, err := newS()
	if err != nil {
		return err
	}
	println(s.X) // ok because err is nil
	func() { println(err) }()
	return nil
}
```

`s` is allocated:

```go
func f10() error {
	s, err := newS()
	println(s.X) // want "field address"
	func() { println(s.X) }()
	return err
}
```